### PR TITLE
03: Add cache for the get API

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,5 @@ DATABASE_PATH=./database/
 DATABASE_NAME=nanoLink.sqlite
 ENV=DEVELOPMENT
 BASE=http://localhost:3000/
+REDIS_HOST=127.0.0.1
+REDIS_PORT=6379

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ npm-debug.log*
 # Database
 database/
 *.sqlite
+
+# Cache
+dump.rdb

--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ npm run setup-db
 ```
 The script will create the database, create the urls table if it doesn’t already exist, and insert two sample records.
 
+### Redis Setup
+
+This project uses Redis for caching. You need to install and start Redis before running the project.
+
+Install Redis on macOS using Homebrew:
+
+```sh
+brew install redis
+```
+
+Start Redis Server:
+
+```sh
+redis-server ./redis.conf
+```
+
+Ensure that Redis is running before starting the project.
+
 ### Development
 
 To start the development server with hot reloading:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,13 @@
         "body-parser": "^1.20.3",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "ioredis": "^5.6.0",
         "sqlite3": "^5.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
         "@types/express": "^5.0.0",
+        "@types/ioredis": "^5.0.0",
         "@types/node": "^22.13.5",
         "@types/sqlite3": "^5.1.0",
         "@types/webpack": "^5.28.5",
@@ -341,6 +343,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "license": "MIT"
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
@@ -730,6 +738,17 @@
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ioredis": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-5.0.0.tgz",
+      "integrity": "sha512-zJbJ3FVE17CNl5KXzdeSPtdltc4tMT3TzC6fxQS0sQngkbFZ6h+0uTafsRqu+eSLIugf6Yb0Ea0SUuRr42Nk9g==",
+      "deprecated": "This is a stub types definition. ioredis provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ioredis": "*"
+      }
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -2116,6 +2135,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2604,6 +2632,15 @@
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -4255,6 +4292,53 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.0.tgz",
+      "integrity": "sha512-tBZlIIWbndeWBWCXWZiqtOF/yxf6yZX3tAlTJ7nfo5jhd6dctNxF7QnYlZLZ1a0o0pDoen7CgZqO+zjNaFbJAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -4673,6 +4757,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -6502,6 +6598,27 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -7152,6 +7269,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
     "body-parser": "^1.20.3",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "ioredis": "^5.6.0",
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@types/express": "^5.0.0",
+    "@types/ioredis": "^5.0.0",
     "@types/node": "^22.13.5",
     "@types/sqlite3": "^5.1.0",
     "@types/webpack": "^5.28.5",

--- a/redis.conf
+++ b/redis.conf
@@ -1,0 +1,2 @@
+maxmemory 100mb
+maxmemory-policy allkeys-lru

--- a/src/routes/linksRouter.ts
+++ b/src/routes/linksRouter.ts
@@ -5,7 +5,7 @@ import { addUrlRecord, getLongUrl, getShortUrl } from '../service/db';
 import bodyParser from 'body-parser';
 import { LinkResponse, LongUrl, ShortUrl } from '../utils/type';
 import { isEmpty, shortenURL } from '../utils/util';
-import { checkDataInCache, setDataInCache } from '../service/cache';
+import { getDataFromCache, setDataInCache } from '../service/cache';
 
 const linksRouter = express.Router();
 
@@ -21,7 +21,7 @@ linksRouter.get(
   async (req: Request<ShortUrl>, res: Response) => {
     try {
       console.log('Requested Short Url', req.params.shortUrl);
-      const dataFromCache = await checkDataInCache(req.params.shortUrl);
+      const dataFromCache = await getDataFromCache(req.params.shortUrl);
       if (dataFromCache) {
         const longUrlFromCache = JSON.parse(dataFromCache);
         console.log('Redirect to:', longUrlFromCache);

--- a/src/routes/linksRouter.ts
+++ b/src/routes/linksRouter.ts
@@ -5,6 +5,7 @@ import { addUrlRecord, getLongUrl, getShortUrl } from '../service/db';
 import bodyParser from 'body-parser';
 import { LinkResponse, LongUrl, ShortUrl } from '../utils/type';
 import { isEmpty, shortenURL } from '../utils/util';
+import { checkDataInCache, setDataInCache } from '../service/cache';
 
 const linksRouter = express.Router();
 
@@ -20,6 +21,14 @@ linksRouter.get(
   async (req: Request<ShortUrl>, res: Response) => {
     try {
       console.log('Requested Short Url', req.params.shortUrl);
+      const dataFromCache = await checkDataInCache(req.params.shortUrl);
+      if (dataFromCache) {
+        const longUrlFromCache = JSON.parse(dataFromCache);
+        console.log('Redirect to:', longUrlFromCache);
+        res.redirect(longUrlFromCache);
+        return;
+      }
+
       const record = await getLongUrl(req.params.shortUrl);
 
       if (record?.LONG_URL) {
@@ -49,12 +58,14 @@ linksRouter.post(
       if (isEmpty(record)) {
         const shortUrl = shortenURL(longUrl);
         await addUrlRecord(shortUrl, longUrl);
+        setDataInCache(shortUrl, longUrl);
         res.json({ shortUrl: BASE + shortUrl });
         return;
       }
 
       // If record exists:
       if (record?.SHORT_URL) {
+        setDataInCache(record?.SHORT_URL, longUrl);
         res.json({ shortUrl: BASE + record.SHORT_URL });
       }
     } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import type { Configuration } from 'webpack';
 import webpackConfig from '../webpack.config';
 import linksRouter from './routes/linksRouter';
 import { closeDB, connectDB } from './service/db';
+import { closeCache, connectCache } from './service/cache';
 
 dotenv.config();
 
@@ -18,6 +19,7 @@ const app = express();
 const compiler = webpack(webpackConfig as Configuration);
 
 connectDB();
+connectCache();
 
 // Enable webpack middleware for hot-reloads in development
 app.use(
@@ -70,6 +72,8 @@ const shutdown = () => {
     console.log('HTTP server closed.');
     // Close database
     closeDB();
+    // Exit cache
+    closeCache();
     process.exit(0);
   });
 };

--- a/src/service/cache.ts
+++ b/src/service/cache.ts
@@ -1,0 +1,99 @@
+import Redis from 'ioredis';
+import * as dotenv from 'dotenv';
+import { OHE_HOUR } from '../utils/const';
+
+dotenv.config();
+
+const CACHE_TIME = process.env.CACHE_TIME
+  ? Number(process.env.CACHE_TIME)
+  : OHE_HOUR;
+const REDIS_HOST = process.env.REDIS_HOST || '127.0.0.1';
+const REDIS_PORT = Number(process.env.REDIS_PORT) || 6379;
+
+let redis: Redis | null = null;
+
+/**
+ * Establishes and returns a Redis connection.
+ * If a connection already exists, it returns the existing instance.
+ * @returns {Redis} Redis client instance.
+ */
+export const connectCache = (): Redis => {
+  if (!redis) {
+    redis = new Redis({
+      host: REDIS_HOST,
+      port: REDIS_PORT,
+    });
+
+    redis.on('connect', () => console.log('Connected to Redis'));
+    redis.on('error', (err) => console.error('Redis error:', err));
+    redis.on('end', () => console.log('Redis connection closed'));
+  }
+
+  return redis;
+};
+
+/**
+ * Retrieves data from the cache using the provided key.
+ * @param {string} cacheKey - The key to search for in Redis.
+ * @returns {Promise<string | null>} The cached data as a string, or null if not found.
+ * @throws {Error} If Redis is not connected.
+ */
+export const checkDataInCache = async (
+  cacheKey: string,
+): Promise<string | null> => {
+  if (!redis) {
+    console.error('Redis is not connected');
+    throw new Error('Redis is not connected');
+  }
+
+  try {
+    const cachedData = await redis.get(cacheKey);
+    console.log(`Cache lookup: Key = ${cacheKey}, Data = ${cachedData}`);
+    return cachedData;
+  } catch (error) {
+    console.error('Error retrieving data from cache:', error);
+    throw error;
+  }
+};
+
+/**
+ * Stores data in the cache with an expiration time.
+ * @param {string} cacheKey - The key under which data will be stored.
+ * @param {unknown} dataToCache - The data to be cached.
+ * @returns {Promise<void>}
+ * @throws {Error} If Redis is not connected.
+ */
+export const setDataInCache = async (
+  cacheKey: string,
+  dataToCache: unknown,
+): Promise<void> => {
+  if (!redis) {
+    console.error('Redis is not connected');
+    throw new Error('Redis is not connected');
+  }
+
+  try {
+    const result = await redis.set(
+      cacheKey,
+      JSON.stringify(dataToCache),
+      'EX',
+      CACHE_TIME,
+    );
+    if (result !== 'OK') {
+      throw new Error('Failed to insert data into cache');
+    }
+  } catch (error) {
+    console.error('Error setting data in cache:', error);
+    throw error;
+  }
+};
+
+export const closeCache = async () => {
+  if (!redis) {
+    console.error('Redis is not connected');
+    return;
+  }
+
+  await redis.quit();
+  console.log('Redis connection closed');
+};

--- a/src/service/cache.ts
+++ b/src/service/cache.ts
@@ -38,7 +38,7 @@ export const connectCache = (): Redis => {
  * @returns {Promise<string | null>} The cached data as a string, or null if not found.
  * @throws {Error} If Redis is not connected.
  */
-export const checkDataInCache = async (
+export const getDataFromCache = async (
   cacheKey: string,
 ): Promise<string | null> => {
   if (!redis) {

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -1,3 +1,4 @@
 export const ENV_DEV = 'DEVELOPMENT';
 export const ENV_PROD = 'PRODUCTION';
 export const URL_LEN_FALLBACK = 18;
+export const OHE_HOUR = 3600;


### PR DESCRIPTION
**Done:**
- Integrated Redis as a caching layer.
- Implemented a read-through cache for the GET API to improve response times and reduce database load.
If requested data is present in Redis, it is returned immediately.
If not, the data is fetched from the database, stored in Redis, and then returned to the client.