### PR TITLE
04: Show error msg when link is not found

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,12 +1,15 @@
 import './styles.css';
 
+const SUPPORTED_ERRORS = new Set(['404']);
+const ERROR_DELAY = 6000;
+
 /**
  * Checks if a given string is a valid URL.
  *
  * @param {string} url - The URL string to validate.
  * @returns {boolean} - Returns `true` if the URL is valid, otherwise `false`.
  */
-export const isValidURL = (url: string) => {
+const isValidURL = (url: string) => {
   try {
     new URL(url);
     return true;
@@ -29,7 +32,25 @@ const copyLinkBtn = document.getElementById('copyLink') as HTMLButtonElement;
 const shortUrlInput = document.getElementById('shortUrl') as HTMLInputElement;
 
 const toggleElementVisibility = (element: HTMLElement, show: boolean) => {
+  if (!element) return;
   element.classList.toggle('hide', !show);
+};
+
+const showErrors = () => {
+  const params = new URLSearchParams(window.location.search);
+  const error = params.get('error');
+  if (error && SUPPORTED_ERRORS.has(error)) {
+    const errorElement = document.getElementById(
+      `${error}Error`,
+    ) as HTMLElement;
+    toggleElementVisibility(errorElement, true);
+
+    setTimeout(() => {
+      if (errorElement) {
+        errorElement.classList.add('hide');
+      }
+    }, ERROR_DELAY); // Auto-hide the error after 6 seconds
+  }
 };
 
 linkInput.addEventListener('input', () => {
@@ -104,3 +125,5 @@ ctaElement?.addEventListener('click', async () => {
     toggleElementVisibility(loaderCopy, false);
   }
 });
+
+showErrors();

--- a/src/routes/linksRouter.ts
+++ b/src/routes/linksRouter.ts
@@ -35,7 +35,7 @@ linksRouter.get(
         console.log('Redirect to:', record.LONG_URL);
         res.redirect(record.LONG_URL);
       } else {
-        res.status(404).json({ error: 'URL not found' });
+        res.redirect('/?error=404');
       }
     } catch (err: unknown) {
       if (err instanceof Error) {

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -27,6 +27,7 @@
         </div>
         <p id="longUrlError" class="error-msg-input error-msg" role="alert">Oops! That doesn't look like a valid link. Please enter a proper URL, like https://example.com</p>
         <p id="genericError" class="error-msg hide" role="alert">Oops! Something went wrong. Give it another try in a moment.</p>
+        <p id="404Error" class="error-msg hide" role="alert">Hmm... That link doesn’t exist in our system. But you can be the first to add it!</p>
       </div>
       <div class="loading hide" id="loader" aria-live="assertive" aria-label="Loading...">
         <span></span>


### PR DESCRIPTION
**Done:**
- Implemented error message handling via the error query parameter (/?error=404).
- If a long URL is not found, the user is redirected to the home page with the error parameter appended.
- The error message is displayed on the home page and automatically disappears after 6 seconds.

<img width="1087" alt="Screenshot 2025-03-06 at 7 13 11 pm" src="https://github.com/user-attachments/assets/dd9f652b-7f4c-4761-be70-556f3650f2d3" />
